### PR TITLE
Fix(TTSDKFileUtils) Time-of-check time-of-use filesystem race condition TikTokBusiness

### DIFF
--- a/TikTokBusinessSDK/TTSDKCrash/TTSDKCrashRecordingCore/TTSDKFileUtils.c
+++ b/TikTokBusinessSDK/TTSDKCrash/TTSDKCrashRecordingCore/TTSDKFileUtils.c
@@ -232,14 +232,15 @@ bool ttsdkfu_readEntireFile(const char *const path, char **data, int *length, in
     int bytesToRead = maxLength;
 
     struct stat st;
-    if (stat(path, &st) < 0) {
-        TTSDKLOG_ERROR("Could not stat %s: %s", path, strerror(errno));
+
+    fd = open(path, O_RDONLY | O_NOFOLLOW);
+    if (fd < 0) {
+        TTSDKLOG_ERROR("Could not open %s: %s", path, strerror(errno));
         goto done;
     }
 
-    fd = open(path, O_RDONLY);
-    if (fd < 0) {
-        TTSDKLOG_ERROR("Could not open %s: %s", path, strerror(errno));
+    if (fstat(fd, &st) < 0) {
+        TTSDKLOG_ERROR("Could not fstat %s: %s", path, strerror(errno));
         goto done;
     }
 


### PR DESCRIPTION
https://github.com/tiktok/tiktok-business-ios-sdk/blob/9b9e060fac22d17885c0916554220e69e102a573/TikTokBusinessSDK/TTSDKCrash/TTSDKCrashRecordingCore/TTSDKFileUtils.c#L235-L240

Fix the TOCTOU issue should eliminate the gap between the `stat` and `open` calls by using a single system call that retrieves the file descriptor and its metadata atomically. The `open` function can be replaced with `open` combined with the `O_NOFOLLOW` flag to prevent symbolic link attacks, and the `fstat` function can be used to retrieve the file's metadata directly from the file descriptor. This ensures that the file being operated on is the same file that was checked.

---

The CERT Oracle Secure Coding Standard for C: [FIO01-C. Be careful using functions that use file names for identification ](https://www.securecoding.cert.org/confluence/display/c/FIO01-C.+Be+careful+using+functions+that+use+file+names+for+identification)
