### PR TITLE
Include missing public headers in umbrella

### DIFF
--- a/TikTokBusinessSDK/TikTokBusinessSDK.h
+++ b/TikTokBusinessSDK/TikTokBusinessSDK.h
@@ -22,3 +22,7 @@ FOUNDATION_EXPORT const unsigned char TikTokBusinessSDKVersionString[];
 #import <TikTokBusinessSDK/TikTokDeviceInfo.h>
 #import <TikTokBusinessSDK/TikTokConstants.h>
 #import <TikTokBusinessSDK/TikTokBusinessSDKAddress.h>
+#import <TikTokBusinessSDK/TikTokAppEventUtility.h>
+#import <TikTokBusinessSDK/TikTokErrorHandler.h>
+#import <TikTokBusinessSDK/TikTokRequestHandler.h>
+#import <TikTokBusinessSDK/TikTokAppEvent.h>


### PR DESCRIPTION
Fixes #48

## Summary
- adds the public app event, app event utility, error handler, and request handler headers to `TikTokBusinessSDK.h`
- keeps the SwiftPM `Public/` symlink layout unchanged

## Validation
- `git diff --check`
- `swift package describe`
- `swift build` was attempted, but this local machine only has Command Line Tools active and no iOS SDK/Xcode; it fails at `UIKit/UIKit.h` before reaching this umbrella change