### PR TITLE
fix(package): Link libc++ explicitly to resolve C++ undefined symbols with SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,7 @@ let package = Package(
                 .headerSearchPath("Storage"),
             ],
             linkerSettings: [
+                .linkedLibrary("c++"),
                 .linkedFramework("UIKit"),
                 .linkedFramework("CoreTelephony"),
                 .linkedFramework("AdSupport"),


### PR DESCRIPTION
## Summary

The SDK contains C++ implementation code, but `Package.swift` did not declare an explicit dependency on `libc++`. Apps that integrate via SPM and don't implicitly link the C++ standard library would encounter build errors like:

```
Undefined symbols for architecture arm64: "std::__1::basic_string<char, ...>"
```


Adding `.linkedLibrary("c++")` to `linkerSettings` in `Package.swift` ensures `libc++` is linked automatically, so integrators no longer need to add `-lc++` manually to their target's Other Linker Flags.