### PR TITLE
Fix Invalid Price Field (40000): serialize content price as a number, omit when nil

### DIFF
--- a/TikTokBusinessSDK/Core/TikTokContentsEvent.m
+++ b/TikTokBusinessSDK/Core/TikTokContentsEvent.m
@@ -28,7 +28,7 @@ NSString * const TTContentsEventNameViewContent   = @"ViewContent";
 
 - (NSDictionary *)dictionaryValue {
     NSMutableDictionary *res = [NSMutableDictionary dictionary];
-    [TikTokTypeUtility dictionary:res setObject:[NSString stringWithFormat:@"%@",self.price] forKey:@"price"];
+    [TikTokTypeUtility dictionary:res setObject:self.price forKey:@"price"];
     [TikTokTypeUtility dictionary:res setObject:@(self.quantity) forKey:@"quantity"];
     [TikTokTypeUtility dictionary:res setObject:self.contentId forKey:@"content_id"];
     [TikTokTypeUtility dictionary:res setObject:self.contentCategory forKey:@"content_category"];

--- a/TikTokBusinessSDKTests/AppEvents/TikTokContentsEventTests.m
+++ b/TikTokBusinessSDKTests/AppEvents/TikTokContentsEventTests.m
@@ -63,4 +63,38 @@
     XCTAssertTrue(event.properties.count == 1, @"Event should have 1 property");
 }
 
+// Reproduces the "Invalid Price Field" (server error 40000) bug: a content item
+// with no price serializes `price` to the literal string "(null)", which the
+// events API rejects — dropping the whole flush batch.
+- (void)testContentWithoutPriceOmitsPriceField {
+    TikTokContentParams *content = [[TikTokContentParams alloc] init];
+    content.contentId = @"sku_1";
+    content.quantity = 1;
+    // price intentionally left unset (nil)
+
+    TikTokViewContentEvent *event = [[TikTokViewContentEvent alloc] init];
+    [event setContents:@[content]];
+
+    NSArray *contents = (NSArray *)[event.properties objectForKey:@"contents"];
+    NSDictionary *first = contents.firstObject;
+    XCTAssertNotNil(first, @"Event should carry a serialized content item");
+    XCTAssertFalse([first[@"price"] isEqual:@"(null)"], @"nil price must not serialize to the string \"(null)\"");
+    XCTAssertNil(first[@"price"], @"price key should be omitted when no price is set");
+}
+
+// A real price must serialize as a number (matching `quantity`), not a string.
+- (void)testContentPriceSerializesAsNumber {
+    TikTokContentParams *content = [[TikTokContentParams alloc] init];
+    content.contentId = @"sku_1";
+    content.price = @(1.1);
+    content.quantity = 1;
+
+    TikTokViewContentEvent *event = [[TikTokViewContentEvent alloc] init];
+    [event setContents:@[content]];
+
+    NSDictionary *first = [(NSArray *)[event.properties objectForKey:@"contents"] firstObject];
+    XCTAssertTrue([first[@"price"] isKindOfClass:[NSNumber class]], @"price should serialize as a number, not a string");
+    XCTAssertEqualObjects(first[@"price"], @(1.1), @"price should preserve its numeric value");
+}
+
 @end


### PR DESCRIPTION
Fixes #63.

## Problem

`TikTokContentParams.dictionaryValue` serializes each content item's `price` via
`stringWithFormat:@"%@"`, which (a) sends `price` as a **string** instead of a
number and (b) turns a `nil` price into the literal string `"(null)"`. The events
API rejects `"(null)"` with `40000 Invalid Price Field`, and because events flush
in batches, one such item drops the **entire batch** — unrelated events silently
never arrive.

Every other field (`contentId`, `contentName`, `brand`, `quantity`) is passed raw
to `TikTokTypeUtility dictionary:setObject:forKey:`, which no-ops on `nil`. Only
`price` was force-stringified.

## Fix

```objc
// before
[TikTokTypeUtility dictionary:res setObject:[NSString stringWithFormat:@"%@",self.price] forKey:@"price"];
// after
[TikTokTypeUtility dictionary:res setObject:self.price forKey:@"price"];
```

- No price → field omitted (no `"(null)"`).
- A set price → serialized as a number (matching `quantity`), not `"1.1"`.

## Tests

Adds two tests to `TikTokContentsEventTests`:
- `testContentWithoutPriceOmitsPriceField`
- `testContentPriceSerializesAsNumber`

Both **fail before** the change and **pass after**.

> Note: the test target doesn't build out-of-the-box on `master` (the
> `TikTokBusinessSDKTestApp` scheme has no test action wired, and a few unrelated
> sibling test files reference removed selectors). I verified locally by wiring
> the test action and isolating these tests; happy to adjust if you run tests
> differently in CI.
